### PR TITLE
Add support for configurable open subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ bindkey "^s" fzf-ssh
   - Uses the public IP if
     - the instance is in a public subnet
     - the security group allows ingress port 22 from the public internet
+    - the security group allows ingress port 22 from subnet provided via `--subnet` flag
   - Otherwise it uses the private IP and routes through the jumphost if one is
     configured.
 - **DigitalOcean**

--- a/cmd.go
+++ b/cmd.go
@@ -11,6 +11,7 @@ var sshUser string
 var identityFile string
 var jumphost string
 var filters string
+var openSubnet string
 
 var rootCmd = &cobra.Command{
 	Use: "generate-ssh-configs",
@@ -90,6 +91,12 @@ func cmdInit() {
 		"filters",
 		"",
 		"AWS instance filters",
+	)
+	awsCmd.Flags().StringVar(
+		&openSubnet,
+		"subnet",
+		"",
+		"Additional open subnet",
 	)
 
 	rootCmd.AddCommand(awsCmd)


### PR DESCRIPTION
I added a `--subnet` command line flag for aws command to support security group settings that do not allow 22 port access to the whole world, but for a specific IP or range. Useful, when you are behind a static IP, but don't want/need a jumpbox.

PR also probably fixes  #3 